### PR TITLE
Add real main path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-merger",
   "version": "0.7.5",
-  "main": "index.js",
+  "main": "./src/main.js",
   "bin": {
     "openapi-merger": "bin/openapi-merger.js"
   },


### PR DESCRIPTION
Node 20 will refuse to run bin commands if main does not reference a real file or directory.  

For example: 
```
node:internal/modules/esm/resolve:189
  const resolvedOption = FSLegacyMainResolve(packageJsonUrlString, packageConfig.main, baseStringified);
                         ^

Error: Cannot find package '/Users/james/foas/node_modules/openapi-merger/package.json' imported from /Users/james/foas/bin/bin.js
    at legacyMainResolve (node:internal/modules/esm/resolve:189:26)
    at packageResolve (node:internal/modules/esm/resolve:776:14)
    at moduleResolve (node:internal/modules/esm/resolve:838:20)
    at defaultResolve (node:internal/modules/esm/resolve:1043:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:383:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:352:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:228:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```