### PR TITLE
Remove URL encoding of path parameters

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -34,6 +34,8 @@ function parseUrl(url) {
     ret.hrefWoHash = ret.href.replace(ret.hash, "");
     // for windows
     ret.hash = ret.hash.replace(/%5C/g, "/");
+    ret.hash = ret.hash.replace(/%7B/g, "{");
+    ret.hash = ret.hash.replace(/%7D/g, "}");
   } else {
     ret.hrefWoHash = ret.href;
   }


### PR DESCRIPTION
If we don't remove URL encoding of path parameters, we are not able to include path definitions with path parameters in them.
E.g:
```
paths:
  /foo/{fooId}:
    $ref: "../bar/bar.yml#/paths/~1bar~1{barId}"
```